### PR TITLE
Add keybase.io integration to blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ learn more about me then check out my [first post][post].
 - Slightly [reddish/pink tint which is good for readers' eyes][flux].
 - Tags and categories.
 - Some social media buttons and Disqus comments for posts.
-- Integrated with GitHub (via the `_config.yml` file).
+- Integrated with GitHub (via the [`_config.yml`][c] file).
   - `make history` generates `_data/updated.yml` based in the git history of
     when a post was last updated.
   - Displays when a post was last updated and links to the history in GitHub
@@ -23,6 +23,7 @@ learn more about me then check out my [first post][post].
   3. production - The live site.
 - Post authoriship is integrated with GPG validation.  This way posts by the
   author can be cryptographically verified.
+- Integrated with [keybase.io][kb.io] (via the [`_config.yml`][c] file).
 
 # Getting started with development
 
@@ -103,10 +104,12 @@ for:
 - Any content governed by 3rd parties which is covered by copyrights, licenses,
   and notices outlined in the [`3rd_party/`](3rd_party) folder.
 
+[c]: _config.yml
 [cc]: https://creativecommons.org/licenses/by-nc-sa/4.0/
 [ci]: https://travis-ci.org/samrocketman/blog
 [ff-gm]: https://addons.mozilla.org/en-us/firefox/addon/greasemonkey/
 [flux]: https://justgetflux.com/research.html
+[kb.io]: https://keybase.io/
 [nvm]: https://github.com/creationix/nvm
 [post]: http://sam.gleske.net/blog/slice-of-life/2015/10/22/intro.html
 [rvm]: https://rvm.io/

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,8 @@ github_branch: master
 twitter_handle: sag47
 #timezone in date TZ format
 timezone: America/Los_Angeles
+keybase_user: samrocketman
+keybase_key: 8D8BF0E242D8A068572EBF3CE8F732347257E65F
 
 markdown: kramdown
 kramdown:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -53,7 +53,13 @@
     <!-- Footer  ==================================== -->
     <footer class="footer">
       <div class="container">
+        {% if site.keybase_user %}
+        <p>
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" title="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International"><img src="https://licensebuttons.net/l/by-nc-sa/3.0/88x31.png" alt="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International" /></a>
+          All original content by <a href="https://keybase.io/{{ site.keybase_user }}/">{{ site.name }}</a>.</p>
+        {% else %}
         <p><a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" title="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International"><img src="https://licensebuttons.net/l/by-nc-sa/3.0/88x31.png" alt="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International" /></a> All original content by {{ site.name }}.</p>
+        {% endif %}
         <p><a href="http://twitter.com/{{ site.twitter_handle }}/">twitter.com/{{ site.twitter_handle }}</a></p>
         <p><a href="{{ site.url }}/feed.xml" title="RSS feed of posts">RSS feed of blog posts</a></p>
       </div>

--- a/make/get_yaml_key.rb
+++ b/make/get_yaml_key.rb
@@ -1,0 +1,14 @@
+#!/bin/ruby
+#Created by Sam Gleske
+#https://github.com/samrocketman/blog
+#Reads a yaml key from _config.yml
+
+require 'yaml'
+
+if ARGV.size > 0 then
+  config = YAML::load_file('_config.yml')
+  result = config[ARGV[0].to_s]
+  if result then
+    puts result
+  end
+end

--- a/make/verify_signatures.sh
+++ b/make/verify_signatures.sh
@@ -15,12 +15,15 @@ set -e
 keyfile=$(mktemp --suffix=.gpg)
 
 GPG="gpg --no-default-keyring --keyring ${keyfile}"
+keybase_user="$(bundle exec ruby ./make/get_yaml_key.rb keybase_user)"
+keybase_key="$(bundle exec ruby ./make/get_yaml_key.rb keybase_key)"
+keybase_url="https://keybase.io/${keybase_user}/pgp_keys.asc?fingerprint=${keybase_key}"
 
-curl -sL 'https://keybase.io/samrocketman/key.asc' | ${GPG} --import
+curl -sL "${keybase_url}" | ${GPG} --import
 
 #fully trust public key 7257E65F
 ${GPG} --import-ownertrust <<EOF
-8D8BF0E242D8A068572EBF3CE8F732347257E65F:6:
+${keybase_key}:6:
 EOF
 
 echo 'Verifying post signatures.'


### PR DESCRIPTION
People who create forks of my blog can set in `_config.yml` their:

- [keybase.io][kb] username.
- [keybase.io][kb] GPG public key fingerprint.

The public key will automatically be imported from keybase as part of `make test` to verify all blog posts were written by the blog owner.

The rendered blog also links to the keybase user account at the bottom.

[kb]: https://keybase.io/